### PR TITLE
Make test_n_publish work all the way to publication

### DIFF
--- a/.github/workflows/test-n-publish.yml
+++ b/.github/workflows/test-n-publish.yml
@@ -73,7 +73,7 @@ jobs:
       with:
         repository: 'spine-tools/${{ matrix.pkg }}'
         path: ${{ matrix.pkg }}
-        ref: ${{ inputs['Spine-Toolbox'] }}
+        ref: ${{ inputs[matrix.pkg] }}
     - name: Set up Python
       uses: actions/setup-python@v4
       with:

--- a/.github/workflows/test-n-publish.yml
+++ b/.github/workflows/test-n-publish.yml
@@ -94,11 +94,6 @@ jobs:
       run: |
         sudo apt-get update -y
         sudo apt-get install -y libegl1
-    - name: Install Python 3 kernelspecs
-      if: matrix.pkg == 'Spine-Toolbox'
-      run: |
-        python -m pip install ipykernel
-        python -m ipykernel install --user
     - name: Remove source from checkouts for *NIX
       if: runner.os != 'Windows'
       run: |

--- a/.github/workflows/test-n-publish.yml
+++ b/.github/workflows/test-n-publish.yml
@@ -83,6 +83,11 @@ jobs:
         python -m pip install --upgrade pip
         pip install dist/*/*.whl
         pip install pytest
+    - name: Install additional packages for Linux
+      if: runner.os == 'Linux'
+      run: |
+        sudo apt-get update -y
+        sudo apt-get install -y libegl1
     - name: Remove source from checkouts
       # FIXME: What is the Windows equivalent?
       run: |

--- a/.github/workflows/test-n-publish.yml
+++ b/.github/workflows/test-n-publish.yml
@@ -37,11 +37,11 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v4
       with:
-        python-version: '3.9'
+        python-version: '3.8'
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install build
+        python -m pip install build
     - name: Build
       run: |
         python -m build ${{ matrix.pkg }}
@@ -57,12 +57,11 @@ jobs:
     strategy:
       matrix:
         pkg: ['Spine-Toolbox', 'spine-items', 'spine-engine', 'Spine-Database-API']
-        os: [ubuntu-latest, macos-latest, windows-latest]
-
+        os: [ubuntu-latest, windows-latest]
+      fail-fast: false
     runs-on: ${{ matrix.os }}
     steps:
     - name: Make dist directory
-      # FIXME: does this work on Windows?
       run: mkdir -p dist
     - name: Download all wheels
       uses: actions/download-artifact@v3
@@ -77,27 +76,60 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v4
       with:
-        python-version: '3.9'
-    - name: Install pytest and built wheels
+        python-version: '3.8'
+    - name: Install pytest and built wheels on *NIX
+      if: runner.os != 'Windows'
       run: |
         python -m pip install --upgrade pip
-        pip install dist/*/*.whl
-        pip install pytest
+        python -m pip install dist/*/*.whl
+        python -m pip install pytest
+    - name: Install pytest and built wheels on Windows
+      if: runner.os == 'Windows'
+      run: |
+        python -m pip install --upgrade pip
+        Get-ChildItem ./dist/*.whl -Recurse | ForEach-Object {python -m pip install $_}
+        python -m pip install pytest
     - name: Install additional packages for Linux
       if: runner.os == 'Linux'
       run: |
         sudo apt-get update -y
         sudo apt-get install -y libegl1
-    - name: Remove source from checkouts
-      # FIXME: What is the Windows equivalent?
+    - name: Install Python 3 kernelspecs
+      if: matrix.pkg == 'Spine-Toolbox'
+      run: |
+        python -m pip install ipykernel
+        python -m ipykernel install --user
+    - name: Remove source from checkouts for *NIX
+      if: runner.os != 'Windows'
       run: |
         rm -rf Spine-Toolbox/spinetoolbox* spine-items/spine_items \
           spine-engine/spine_engine Spine-Database-API/spinedb_api
-    - name: Test wheels
+    - name: Remove source from checkouts for Windows
+      if: runner.os == 'Windows'
+      run: |
+        Remove-Item Spine-Toolbox\spinetoolbox* -Recurse -Force -ErrorAction Ignore
+        Remove-Item spine-items\spine_items -Recurse -Force -ErrorAction Ignore
+        Remove-Item spine-engine\spine_engine -Recurse -Force -ErrorAction Ignore
+        Remove-Item Spine-Database-API\spinedb_api -Recurse -Force -ErrorAction Ignore
+    - name: Test wheels on *NIX
+      if: runner.os != 'Windows'
+      # FIXME: how to run execution tests for Spine-Toolbox
+      env:
+        QT_QPA_PLATFORM: offscreen
+      run: |
+        # FIXME: The cd stuff below is a workaround for bug in spinetoolbox tests
+        cd ${{ matrix.pkg }}
+        python -m unittest discover --verbose
+        cd ..
+        # FIXME: Use the line below once spine-tools/Spine-Toolbox#2274 is fixed
+        #python -m unittest discover -s ${{ matrix.pkg }} --verbose
+    - name: Test wheels on Windows
+      if: runner.os == 'Windows'
       # FIXME: how to run execution tests for Spine-Toolbox
       run: |
-        python -m unittest discover -s ${{ matrix.pkg }}
-
+        cd ${{ matrix.pkg }}
+        python -m unittest discover --verbose
+        cd ..
   publish:
     # isolate from test, to prevent partial uploads
     needs: test
@@ -118,6 +150,6 @@ jobs:
       uses: pypa/gh-action-pypi-publish@release/v1
       with:
         # repository-url: https://test.pypi.org/legacy/
-        packages-dir: dist/${{ matrix.pkg}}
+        packages-dir: dist/${{ matrix.pkg }}
         # skip-existing: true
         # verify-metadata: false


### PR DESCRIPTION
With these changes we managed to get Toolbox tested and published all the way to PyPI in the GitHub action with @PekkaSavolainen. Pprobably not the most beautiful GitHub action but at least it gets the job done and thus serves as a good starting point for future improvements. Some notes on `test-n-publish.yml`:

- Testing was disabled for `macos-latest`. We should first run the tests and fix macOS in the development CIs (see spine-tools/Spine-Toolbox#2273) before enabling the platform here.
- Some of the FIXMEs in can be fixed after spine-tools/Spine-Toolbox#2274 has been fixed.
- Execution tests are still missing here.