### PR TITLE
workflows/test-n-publish: check if tag is checked out correctly

### DIFF
--- a/.github/workflows/test-n-publish.yml
+++ b/.github/workflows/test-n-publish.yml
@@ -74,6 +74,10 @@ jobs:
         repository: 'spine-tools/${{ matrix.pkg }}'
         path: ${{ matrix.pkg }}
         ref: ${{ inputs[matrix.pkg] }}
+    - name: Ensure Git checkout is not dirty
+      run: GIT_DIR=${{ matrix.pkg }}/.git git describe --tags --dirty | grep -vE '[-]dirty$' -q
+    - name: Ensure Git checkout does not have additional commits
+      run: GIT_DIR=${{ matrix.pkg }}/.git git describe --tags | grep -vE '[-]g[a-z0-9]{8}$' -q
     - name: Set up Python ${{ matrix.python }}
       uses: actions/setup-python@v4
       with:


### PR DESCRIPTION
Fixes #18; fail if:
- checkout is dirty
- checkout has additional commits after a tag