### PR TITLE
Update publish workflow to update individual packages

### DIFF
--- a/.github/workflows/publish-wheel.yml
+++ b/.github/workflows/publish-wheel.yml
@@ -1,0 +1,34 @@
+name: Reusable workflow to publish Spine package wheels
+
+on:
+  workflow_call:
+    inputs:
+      pkg:
+        description: Package name
+        type: string
+        required: true
+      ver:
+        description: Release tag
+        type: string
+        required: true
+
+jobs:
+  publish-whl:
+    if: ${{ inputs.ver }} != 'skip'
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+    steps:
+    - name: Make dist directory
+      run: mkdir -p dist
+    - name: Download all wheels
+      uses: actions/download-artifact@v3
+      with:
+        path: dist
+    - name: Publish to PyPI using trusted publishing
+      uses: pypa/gh-action-pypi-publish@release/v1
+      with:
+        # repository-url: https://test.pypi.org/legacy/
+        packages-dir: dist/${{ inputs.pkg }}
+        # skip-existing: true
+        # verify-metadata: false

--- a/.github/workflows/test-n-publish.yml
+++ b/.github/workflows/test-n-publish.yml
@@ -24,7 +24,7 @@ jobs:
   build:
     strategy:
       matrix:
-        pkg: ['Spine-Toolbox', 'spine-items', 'spine-engine', 'Spine-Database-API']
+        pkg: ['Spine-Database-API', 'spine-engine', 'spine-items', 'Spine-Toolbox']
 
     runs-on: ubuntu-latest
     steps:
@@ -60,7 +60,7 @@ jobs:
     needs: build
     strategy:
       matrix:
-        pkg: ['Spine-Toolbox', 'spine-items', 'spine-engine', 'Spine-Database-API']
+        pkg: ['Spine-Database-API', 'spine-engine', 'spine-items', 'Spine-Toolbox']
         os: [ubuntu-latest, windows-latest]
         python: ["3.8", "3.9", "3.10", "3.11"]
       fail-fast: false
@@ -127,7 +127,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        pkg: ['Spine-Toolbox', 'spine-items', 'spine-engine', 'Spine-Database-API']
+        pkg: ['Spine-Database-API', 'spine-engine', 'spine-items', 'Spine-Toolbox']
     permissions:
       id-token: write
     steps:

--- a/.github/workflows/test-n-publish.yml
+++ b/.github/workflows/test-n-publish.yml
@@ -5,20 +5,20 @@ on:
     inputs:
       Spine-Toolbox:
         description: Git tag to use for 'Spine-Toolbox'
-        required: true
         type: string
+        default: 'skip'
       spine-items:
         description: Git tag to use for 'spine-items'
-        required: true
         type: string
+        default: 'skip'
       spine-engine:
         description: Git tag to use for 'spine-engine'
-        required: true
         type: string
+        default: 'skip'
       Spine-Database-API:
         description: Git tag to use for 'Spine-Database-API'
-        required: true
         type: string
+        default: 'skip'
 
 jobs:
   build:
@@ -26,6 +26,7 @@ jobs:
       matrix:
         pkg: ['Spine-Database-API', 'spine-engine', 'spine-items', 'Spine-Toolbox']
 
+    if: ${{ inputs[matrix.pkg] }} != 'skip'
     runs-on: ubuntu-latest
     steps:
     - name: Checkout ${{ matrix.pkg }}
@@ -64,6 +65,7 @@ jobs:
         os: [ubuntu-latest, windows-latest]
         python: ["3.8", "3.9", "3.10", "3.11"]
       fail-fast: false
+    if: ${{ inputs[matrix.pkg] }} != 'skip'
     runs-on: ${{ matrix.os }}
     steps:
     - name: Make dist directory
@@ -124,6 +126,7 @@ jobs:
   publish:
     # isolate from test, to prevent partial uploads
     needs: test
+    if: ${{ inputs[matrix.pkg] }} != 'skip'
     runs-on: ubuntu-latest
     strategy:
       matrix:

--- a/.github/workflows/test-n-publish.yml
+++ b/.github/workflows/test-n-publish.yml
@@ -26,7 +26,6 @@ jobs:
       matrix:
         pkg: ['Spine-Database-API', 'spine-engine', 'spine-items', 'Spine-Toolbox']
 
-    if: ${{ inputs[matrix.pkg] }} != 'skip'
     runs-on: ubuntu-latest
     steps:
     - name: Checkout ${{ matrix.pkg }}
@@ -48,8 +47,16 @@ jobs:
         python -m pip install --upgrade pip
         python -m pip install build
     - name: Build
+      if: ${{ inputs[matrix.pkg] }} != 'skip'
       run: |
         python -m build ${{ matrix.pkg }}
+    - name: Download wheels for packages excluded from build
+      if: ${{ inputs[matrix.pkg] }} == 'skip'
+      run: |
+        mkdir -p ${{ matrix.pkg }}/dist/
+        sed -nEe 's/name[ ]*=[ ]*"?([a-z0-9_-]+)"?/\1/p' ${{ matrix.pkg }}/pyproject.toml > pkgname
+        python -m pip download --no-deps --python-version 3.8 \
+          --dest ${{ matrix.pkg }}/dist/ $(cat pkgname)
     - name: Save ${{ matrix.pkg }} wheel
       uses: actions/upload-artifact@v3
       with:
@@ -65,7 +72,6 @@ jobs:
         os: [ubuntu-latest, windows-latest]
         python: ["3.8", "3.9", "3.10", "3.11"]
       fail-fast: false
-    if: ${{ inputs[matrix.pkg] }} != 'skip'
     runs-on: ${{ matrix.os }}
     steps:
     - name: Make dist directory
@@ -126,24 +132,11 @@ jobs:
   publish:
     # isolate from test, to prevent partial uploads
     needs: test
-    if: ${{ inputs[matrix.pkg] }} != 'skip'
-    runs-on: ubuntu-latest
     strategy:
       matrix:
         pkg: ['Spine-Database-API', 'spine-engine', 'spine-items', 'Spine-Toolbox']
-    permissions:
-      id-token: write
-    steps:
-    - name: Make dist directory
-      run: mkdir -p dist
-    - name: Download all wheels
-      uses: actions/download-artifact@v3
-      with:
-        path: dist
-    - name: Publish to PyPI using trusted publishing
-      uses: pypa/gh-action-pypi-publish@release/v1
-      with:
-        # repository-url: https://test.pypi.org/legacy/
-        packages-dir: dist/${{ matrix.pkg }}
-        # skip-existing: true
-        # verify-metadata: false
+
+    uses: ./.github/workflows/publish-wheel.yml
+    with:
+      pkg: ${{ matrix.pkg }}
+      ver: ${{ inputs[matrix.pkg] }}

--- a/.github/workflows/unittests.yml
+++ b/.github/workflows/unittests.yml
@@ -3,14 +3,14 @@ name: Unit tests
 on:
   push:
     paths-ignore:
-      - "doc/**"
+      - "docs/**"
       - "*.md"
-      - ".github/workflows/test-n-publish.yml"
+      - ".github/workflows/*publish*.yml"
   pull_request:
     paths-ignore:
-      - "doc/**"
+      - "docs/**"
       - "*.md"
-      - ".github/workflows/test-n-publish.yml"
+      - ".github/workflows/*publish*.yml"
 
 jobs:
   format:


### PR DESCRIPTION
This resolves #17 

### The implemented behaviour
- When publishing all 4 packages, behave as before
- When publishing less than 4 packages, the workflow downloads the latest released wheel for the missing package to run the test suite.  Publishes only on success

Note that before this works, spine-tools/spine-toolbox#2426 has to merged.  Currently it will fail like [this](https://github.com/suvayu/spine-conductor/actions/runs/6986421894)