### PR TITLE
Fix test-n-publish

### DIFF
--- a/.github/workflows/publish-wheel.yml
+++ b/.github/workflows/publish-wheel.yml
@@ -14,7 +14,7 @@ on:
 
 jobs:
   publish-whl:
-    if: ${{ inputs.ver }} != 'skip'
+    if: ${{ inputs.ver  != 'skip' }}
     runs-on: ubuntu-latest
     permissions:
       id-token: write
@@ -22,7 +22,7 @@ jobs:
     - name: Make dist directory
       run: mkdir -p dist
     - name: Download all wheels
-      uses: actions/download-artifact@v3
+      uses: actions/download-artifact@v4
       with:
         path: dist
     - name: Publish to PyPI using trusted publishing

--- a/.github/workflows/test-n-publish.yml
+++ b/.github/workflows/test-n-publish.yml
@@ -107,12 +107,12 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         python -m pip install pytest
-    - name: Install pytest and built wheels on *NIX
+    - name: Built wheels on *NIX
       if: ${{ inputs[matrix.pkg]  != 'skip' && runner.os != 'Windows' }}
       run: |
         ls dist
         python -m pip install dist/*/*.whl
-    - name: Install pytest and built wheels on Windows
+    - name: Built wheels on Windows
       if: ${{ inputs[matrix.pkg]  != 'skip' && runner.os == 'Windows' }}
       run: |
         Get-ChildItem ./dist/*.whl -Recurse | ForEach-Object {python -m pip install $_}
@@ -145,12 +145,35 @@ jobs:
         python -m unittest discover -s ${{ matrix.pkg }} --pattern execution_test.py --verbose
 
   publish:
-    # isolate from test, to prevent partial uploads
     needs: test
     strategy:
       matrix:
         pkg: ['Spine-Database-API', 'spine-engine', 'spine-items', 'Spine-Toolbox']
-    uses: ./.github/workflows/publish-wheel.yml
-    with:
-      pkg: ${{ matrix.pkg }}
-      ver: ${{ inputs[matrix.pkg] }}
+    runs-on: ubuntu-latest
+    environment:
+      name: pypi
+      url: https://pypi.org/p/${{ steps.package_name.outputs.name }}
+    permissions:
+      id-token: write
+    steps:
+    - name: Make dist directory
+      if: ${{ inputs[matrix.pkg]  != 'skip' }}
+      run: mkdir -p dist
+    - name: Download package wheel
+      if: ${{ inputs[matrix.pkg]  != 'skip' }}
+      uses: actions/download-artifact@v4
+      with:
+        name: ${{ matrix.pkg }}
+        path: dist
+    - id: package_name
+      if: ${{ inputs[matrix.pkg]  != 'skip' }}
+      run: |
+        echo name=$(ls dist | awk -F'[-]' '{print $1}') >> $GITHUB_OUTPUT
+    - name: Publish to PyPI using trusted publishing
+      if: ${{ inputs[matrix.pkg]  != 'skip' }}
+      uses: pypa/gh-action-pypi-publish@release/v1
+      # with:
+        # repository-url: https://test.pypi.org/legacy/
+        # packages-dir: dist/
+        # skip-existing: true
+        # verify-metadata: false

--- a/.github/workflows/test-n-publish.yml
+++ b/.github/workflows/test-n-publish.yml
@@ -25,21 +25,29 @@ jobs:
     strategy:
       matrix:
         pkg: ['Spine-Database-API', 'spine-engine', 'spine-items', 'Spine-Toolbox']
-
     runs-on: ubuntu-latest
     steps:
-    - name: Checkout ${{ matrix.pkg }}
-      uses: actions/checkout@v3
+    - name: Checkout ${{ matrix.pkg }} for publishing
+      if: ${{ inputs[matrix.pkg]  != 'skip' }}
+      uses: actions/checkout@v4
       with:
         repository: 'spine-tools/${{ matrix.pkg }}'
         path: ${{ matrix.pkg }}
         ref: ${{ inputs[matrix.pkg] }}
+    - name: Checkout ${{ matrix.pkg }} for testing only
+      if: ${{ inputs[matrix.pkg]  == 'skip' }}
+      uses: actions/checkout@v4
+      with:
+        repository: 'spine-tools/${{ matrix.pkg }}'
+        path: ${{ matrix.pkg }}
     - name: Ensure Git checkout is not dirty
+      if: ${{ inputs[matrix.pkg]  != 'skip' }}
       run: cd ${{ matrix.pkg }} && git describe --tags --dirty | grep -vE '[-]dirty$'
     - name: Ensure Git checkout does not have additional commits
+      if: ${{ inputs[matrix.pkg]  != 'skip' }}
       run: cd ${{ matrix.pkg }} && git describe --tags | grep -vE '[-]g[a-z0-9]{8}$'
     - name: Set up Python
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v5
       with:
         python-version: '3.8'
     - name: Install dependencies
@@ -47,18 +55,18 @@ jobs:
         python -m pip install --upgrade pip
         python -m pip install build
     - name: Build
-      if: ${{ inputs[matrix.pkg] }} != 'skip'
+      if: ${{ inputs[matrix.pkg]  != 'skip' }}
       run: |
         python -m build ${{ matrix.pkg }}
     - name: Download wheels for packages excluded from build
-      if: ${{ inputs[matrix.pkg] }} == 'skip'
+      if: ${{ inputs[matrix.pkg]  == 'skip' }}
       run: |
         mkdir -p ${{ matrix.pkg }}/dist/
         sed -nEe 's/name[ ]*=[ ]*"?([a-z0-9_-]+)"?/\1/p' ${{ matrix.pkg }}/pyproject.toml > pkgname
-        python -m pip download --no-deps --python-version 3.8 \
+        python -m pip download --no-deps --python-version 3.8.1 \
           --dest ${{ matrix.pkg }}/dist/ $(cat pkgname)
     - name: Save ${{ matrix.pkg }} wheel
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: ${{ matrix.pkg }}
         path: ${{ matrix.pkg }}/dist/*
@@ -75,57 +83,64 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
     - name: Make dist directory
+      if: ${{ inputs[matrix.pkg]  != 'skip' }}
       run: mkdir -p dist
     - name: Download all wheels
-      uses: actions/download-artifact@v3
+      if: ${{ inputs[matrix.pkg]  != 'skip' }}
+      uses: actions/download-artifact@v4
       with:
         path: dist
     - name: Checkout ${{ matrix.pkg }}
-      uses: actions/checkout@v3
+      if: ${{ inputs[matrix.pkg]  != 'skip' }}
+      uses: actions/checkout@v4
       with:
         repository: 'spine-tools/${{ matrix.pkg }}'
         path: ${{ matrix.pkg }}
         ref: ${{ inputs[matrix.pkg] }}
     - name: Set up Python ${{ matrix.python }}
-      uses: actions/setup-python@v4
+      if: ${{ inputs[matrix.pkg]  != 'skip' }}
+      uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python }}
+    - name: Upgrade Pip and install pytest
+      if: ${{ inputs[matrix.pkg]  != 'skip' }}
+      run: |
+        python -m pip install --upgrade pip
+        python -m pip install pytest
     - name: Install pytest and built wheels on *NIX
-      if: runner.os != 'Windows'
+      if: ${{ inputs[matrix.pkg]  != 'skip' && runner.os != 'Windows' }}
       run: |
-        python -m pip install --upgrade pip
+        ls dist
         python -m pip install dist/*/*.whl
-        python -m pip install pytest
     - name: Install pytest and built wheels on Windows
-      if: runner.os == 'Windows'
+      if: ${{ inputs[matrix.pkg]  != 'skip' && runner.os == 'Windows' }}
       run: |
-        python -m pip install --upgrade pip
         Get-ChildItem ./dist/*.whl -Recurse | ForEach-Object {python -m pip install $_}
-        python -m pip install pytest
     - name: Install additional packages for Linux
-      if: runner.os == 'Linux'
+      if: ${{ inputs[matrix.pkg]  != 'skip' && runner.os == 'Linux' }}
       run: |
         sudo apt-get update -y
         sudo apt-get install -y libegl1
     - name: Remove source from checkouts for *NIX
-      if: runner.os != 'Windows'
+      if: ${{ inputs[matrix.pkg]  != 'skip' && runner.os != 'Windows' }}
       run: |
         rm -rf Spine-Toolbox/spinetoolbox* spine-items/spine_items \
           spine-engine/spine_engine Spine-Database-API/spinedb_api
     - name: Remove source from checkouts for Windows
-      if: runner.os == 'Windows'
+      if: ${{ inputs[matrix.pkg]  != 'skip' && runner.os == 'Windows' }}
       run: |
         Remove-Item Spine-Toolbox\spinetoolbox* -Recurse -Force -ErrorAction Ignore
         Remove-Item spine-items\spine_items -Recurse -Force -ErrorAction Ignore
         Remove-Item spine-engine\spine_engine -Recurse -Force -ErrorAction Ignore
         Remove-Item Spine-Database-API\spinedb_api -Recurse -Force -ErrorAction Ignore
     - name: Test wheels
+      if: ${{ inputs[matrix.pkg]  != 'skip' }}
       env:
         QT_QPA_PLATFORM: offscreen
       run: |
         python -m unittest discover -s ${{ matrix.pkg }} --verbose
     - name: Execution tests
-      if: matrix.pkg == 'Spine-Toolbox'
+      if: ${{ inputs[matrix.pkg]  != 'skip' && matrix.pkg == 'Spine-Toolbox' }}
       run: |
         python -m unittest discover -s ${{ matrix.pkg }} --pattern execution_test.py --verbose
 
@@ -135,7 +150,6 @@ jobs:
     strategy:
       matrix:
         pkg: ['Spine-Database-API', 'spine-engine', 'spine-items', 'Spine-Toolbox']
-
     uses: ./.github/workflows/publish-wheel.yml
     with:
       pkg: ${{ matrix.pkg }}


### PR DESCRIPTION
This PR fixes the test-n-publish workflow.

- The `skip` tag did not work
- Packages cannot be published from reusable workflows, see https://github.com/pypi/warehouse/issues/11096

The publishing step still fails but that is because uploads to PyPI are currently disabled if I understood correctly.