### PR TITLE
Refactor workflows to separate different conditions

### DIFF
--- a/.github/actions/build-wheel/action.yml
+++ b/.github/actions/build-wheel/action.yml
@@ -1,0 +1,35 @@
+name: Build wheel
+description: Composite action to build Spine package wheels
+
+inputs:
+  pkg:
+    description: Package name
+    type: string
+    required: true
+  ver:
+    description: Release tag
+    type: string
+    required: true
+
+runs:
+  using: composite
+  steps:
+  - name: Checkout ${{ inputs.pkg }}==${{ inputs.ver }}
+    uses: actions/checkout@v4
+    with:
+      repository: 'spine-tools/${{ inputs.pkg }}'
+      path: ${{ inputs.pkg }}
+      ref: ${{ inputs.ver }}
+  - name: Ensure Git checkout is not dirty
+    # this may happen if repo has files w/ different line-endings
+    shell: bash
+    run: |
+      cd ${{ inputs.pkg }} && git describe --tags --dirty | grep -vE '[-]dirty$'
+  - name: Ensure there are no additional commits since latest release
+    shell: bash
+    run: |
+      cd ${{ inputs.pkg }} && git describe --tags | grep -vE '[-]g[a-z0-9]{7,10}$'
+  - name: Build ${{ inputs.pkg }}==${{ inputs.ver }}
+    shell: bash
+    run: |
+      python -m build ${{ inputs.pkg }}

--- a/.github/actions/download-wheel/action.yml
+++ b/.github/actions/download-wheel/action.yml
@@ -1,0 +1,30 @@
+name: Download wheel
+description: Composite action to download Spine package wheels from PyPI
+
+inputs:
+  pkg:
+    description: Package name
+    type: string
+    required: true
+  python:
+    description: Python version
+    type: string
+    required: true
+
+runs:
+  using: composite
+  steps:
+  - name: Checkout ${{ inputs.pkg }}
+    uses: actions/checkout@v4
+    with:
+      repository: 'spine-tools/${{ inputs.pkg }}'
+      path: ${{ inputs.pkg }}
+  - name: Download latest wheel for package excluded from build
+    shell: bash
+    run: |
+      mkdir -p ${{ inputs.pkg }}/dist/
+      sed -nEe 's/name[ ]*=[ ]*"?([a-z0-9_-]+)"?/\1/p' \
+        ${{ inputs.pkg }}/pyproject.toml > pkgname
+      echo "Downloading $(cat pkgname)"
+      python -m pip download --no-deps --python-version ${{ inputs.python }} \
+        --dest ${{ inputs.pkg }}/dist/ $(cat pkgname)

--- a/.github/workflows/publish-wheel.yml
+++ b/.github/workflows/publish-wheel.yml
@@ -14,7 +14,7 @@ on:
 
 jobs:
   publish-whl:
-    if: ${{ inputs.ver }} != 'skip'
+    if: inputs.ver != 'skip'
     runs-on: ubuntu-latest
     permissions:
       id-token: write
@@ -22,7 +22,7 @@ jobs:
     - name: Make dist directory
       run: mkdir -p dist
     - name: Download all wheels
-      uses: actions/download-artifact@v3
+      uses: actions/download-artifact@v4
       with:
         path: dist
     - name: Publish to PyPI using trusted publishing

--- a/.github/workflows/test-n-publish.yml
+++ b/.github/workflows/test-n-publish.yml
@@ -48,7 +48,7 @@ jobs:
       run: cd ${{ matrix.pkg }} && git describe --tags --dirty | grep -vE '[-]dirty$'
     - name: Ensure Git checkout does not have additional commits
       if: inputs[matrix.pkg]  != 'skip'
-      run: cd ${{ matrix.pkg }} && git describe --tags | grep -vE '[-]g[a-z0-9]{8}$'
+      run: cd ${{ matrix.pkg }} && git describe --tags | grep -vE '[-]g[a-z0-9]{7,10}$'
     - name: Build
       if: inputs[matrix.pkg] != 'skip'
       run: |

--- a/.github/workflows/test-n-publish.yml
+++ b/.github/workflows/test-n-publish.yml
@@ -25,42 +25,43 @@ jobs:
     strategy:
       matrix:
         pkg: ['Spine-Database-API', 'spine-engine', 'spine-items', 'Spine-Toolbox']
+        python: ["3.8.1"]
 
     runs-on: ubuntu-latest
     steps:
     - name: Checkout ${{ matrix.pkg }}
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
       with:
         repository: 'spine-tools/${{ matrix.pkg }}'
         path: ${{ matrix.pkg }}
         ref: ${{ inputs[matrix.pkg] }}
     - name: Ensure Git checkout is not dirty
-      if: ${{ inputs[matrix.pkg]  != 'skip' }}
+      if: inputs[matrix.pkg]  != 'skip'
       run: cd ${{ matrix.pkg }} && git describe --tags --dirty | grep -vE '[-]dirty$'
     - name: Ensure Git checkout does not have additional commits
-      if: ${{ inputs[matrix.pkg]  != 'skip' }}
+      if: inputs[matrix.pkg]  != 'skip'
       run: cd ${{ matrix.pkg }} && git describe --tags | grep -vE '[-]g[a-z0-9]{8}$'
     - name: Set up Python
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v5
       with:
-        python-version: '3.8'
+        python-version: ${{ matrix.python }}
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
         python -m pip install build
     - name: Build
-      if: ${{ inputs[matrix.pkg]  != 'skip' }}
+      if: inputs[matrix.pkg] != 'skip'
       run: |
         python -m build ${{ matrix.pkg }}
     - name: Download wheels for packages excluded from build
-      if: ${{ inputs[matrix.pkg]  == 'skip' }}
+      if: inputs[matrix.pkg] == 'skip'
       run: |
         mkdir -p ${{ matrix.pkg }}/dist/
         sed -nEe 's/name[ ]*=[ ]*"?([a-z0-9_-]+)"?/\1/p' ${{ matrix.pkg }}/pyproject.toml > pkgname
-        python -m pip download --no-deps --python-version 3.8.1 \
+        python -m pip download --no-deps --python-version ${{ matrix.python }} \
           --dest ${{ matrix.pkg }}/dist/ $(cat pkgname)
     - name: Save ${{ matrix.pkg }} wheel
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: ${{ matrix.pkg }}
         path: ${{ matrix.pkg }}/dist/*

--- a/.github/workflows/test-n-publish.yml
+++ b/.github/workflows/test-n-publish.yml
@@ -29,6 +29,14 @@ jobs:
 
     runs-on: ubuntu-latest
     steps:
+    - name: Set up Python
+      uses: actions/setup-python@v5
+      with:
+        python-version: ${{ matrix.python }}
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        python -m pip install build
     - name: Checkout ${{ matrix.pkg }}
       uses: actions/checkout@v4
       with:
@@ -41,14 +49,6 @@ jobs:
     - name: Ensure Git checkout does not have additional commits
       if: inputs[matrix.pkg]  != 'skip'
       run: cd ${{ matrix.pkg }} && git describe --tags | grep -vE '[-]g[a-z0-9]{8}$'
-    - name: Set up Python
-      uses: actions/setup-python@v5
-      with:
-        python-version: ${{ matrix.python }}
-    - name: Install dependencies
-      run: |
-        python -m pip install --upgrade pip
-        python -m pip install build
     - name: Build
       if: inputs[matrix.pkg] != 'skip'
       run: |

--- a/.github/workflows/test-n-publish.yml
+++ b/.github/workflows/test-n-publish.yml
@@ -25,7 +25,7 @@ jobs:
     strategy:
       matrix:
         pkg: ['Spine-Database-API', 'spine-engine', 'spine-items', 'Spine-Toolbox']
-        python: ["3.8.1"]
+        python: ["3.12"]
 
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/test-n-publish.yml
+++ b/.github/workflows/test-n-publish.yml
@@ -75,62 +75,13 @@ jobs:
         os: [ubuntu-latest, windows-latest]
         python: ["3.8", "3.9", "3.10", "3.11", "3.12"]
       fail-fast: false
-    runs-on: ${{ matrix.os }}
-    steps:
-    - name: Make dist directory
-      run: mkdir -p dist
-    - name: Download all wheels
-      uses: actions/download-artifact@v3
-      with:
-        path: dist
-    - name: Checkout ${{ matrix.pkg }}
-      uses: actions/checkout@v3
-      with:
-        repository: 'spine-tools/${{ matrix.pkg }}'
-        path: ${{ matrix.pkg }}
-        ref: ${{ inputs[matrix.pkg] != 'skip' && inputs[matrix.pkg] || 'master' }}
-    - name: Set up Python ${{ matrix.python }}
-      uses: actions/setup-python@v4
-      with:
-        python-version: ${{ matrix.python }}
-    - name: Install pytest and built wheels on *NIX
-      if: runner.os != 'Windows'
-      run: |
-        python -m pip install --upgrade pip
-        python -m pip install dist/*/*.whl
-        python -m pip install pytest
-    - name: Install pytest and built wheels on Windows
-      if: runner.os == 'Windows'
-      run: |
-        python -m pip install --upgrade pip
-        Get-ChildItem ./dist/*.whl -Recurse | ForEach-Object {python -m pip install $_}
-        python -m pip install pytest
-    - name: Install additional packages for Linux
-      if: runner.os == 'Linux'
-      run: |
-        sudo apt-get update -y
-        sudo apt-get install -y libegl1
-    - name: Remove source from checkouts for *NIX
-      if: runner.os != 'Windows'
-      run: |
-        rm -rf Spine-Toolbox/spinetoolbox* spine-items/spine_items \
-          spine-engine/spine_engine Spine-Database-API/spinedb_api
-    - name: Remove source from checkouts for Windows
-      if: runner.os == 'Windows'
-      run: |
-        Remove-Item Spine-Toolbox\spinetoolbox* -Recurse -Force -ErrorAction Ignore
-        Remove-Item spine-items\spine_items -Recurse -Force -ErrorAction Ignore
-        Remove-Item spine-engine\spine_engine -Recurse -Force -ErrorAction Ignore
-        Remove-Item Spine-Database-API\spinedb_api -Recurse -Force -ErrorAction Ignore
-    - name: Test wheels
-      env:
-        QT_QPA_PLATFORM: offscreen
-      run: |
-        python -m unittest discover -s ${{ matrix.pkg }} --verbose
-    - name: Execution tests
-      if: matrix.pkg == 'Spine-Toolbox'
-      run: |
-        python -m unittest discover -s ${{ matrix.pkg }} --pattern execution_test.py --verbose
+
+    uses: ./.github/workflows/test-wheel.yml
+    with:
+      pkg: ${{ matrix.pkg }}
+      ver: ${{ inputs[matrix.pkg] }}
+      os: ${{ matrix.os }}
+      python: ${{ matrix.python }}
 
   publish:
     # isolate from test, to prevent partial uploads

--- a/.github/workflows/test-n-publish.yml
+++ b/.github/workflows/test-n-publish.yml
@@ -29,6 +29,8 @@ jobs:
 
     runs-on: ubuntu-latest
     steps:
+    - name: Checkout spine-conductor (for actions)
+      uses: actions/checkout@v4
     - name: Set up Python
       uses: actions/setup-python@v5
       with:
@@ -37,29 +39,18 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         python -m pip install build
-    - name: Checkout ${{ matrix.pkg }}
-      uses: actions/checkout@v4
+    - name: Build ${{ matrix.pkg }}==${{ inputs[matrix.pkg] }}
+      if: inputs[matrix.pkg]  != 'skip'
+      uses: ./.github/actions/build-wheel
       with:
-        repository: 'spine-tools/${{ matrix.pkg }}'
-        path: ${{ matrix.pkg }}
-        ref: ${{ inputs[matrix.pkg] }}
-    - name: Ensure Git checkout is not dirty
-      if: inputs[matrix.pkg]  != 'skip'
-      run: cd ${{ matrix.pkg }} && git describe --tags --dirty | grep -vE '[-]dirty$'
-    - name: Ensure Git checkout does not have additional commits
-      if: inputs[matrix.pkg]  != 'skip'
-      run: cd ${{ matrix.pkg }} && git describe --tags | grep -vE '[-]g[a-z0-9]{7,10}$'
-    - name: Build
-      if: inputs[matrix.pkg] != 'skip'
-      run: |
-        python -m build ${{ matrix.pkg }}
-    - name: Download wheels for packages excluded from build
+        pkg: ${{ matrix.pkg }}
+        ver: ${{ inputs[matrix.pkg] }}
+    - name: Download ${{ matrix.pkg }}
       if: inputs[matrix.pkg] == 'skip'
-      run: |
-        mkdir -p ${{ matrix.pkg }}/dist/
-        sed -nEe 's/name[ ]*=[ ]*"?([a-z0-9_-]+)"?/\1/p' ${{ matrix.pkg }}/pyproject.toml > pkgname
-        python -m pip download --no-deps --python-version ${{ matrix.python }} \
-          --dest ${{ matrix.pkg }}/dist/ $(cat pkgname)
+      uses: ./.github/actions/download-wheel
+      with:
+        pkg: ${{ matrix.pkg }}
+        python: ${{ matrix.python }}
     - name: Save ${{ matrix.pkg }} wheel
       uses: actions/upload-artifact@v4
       with:

--- a/.github/workflows/test-n-publish.yml
+++ b/.github/workflows/test-n-publish.yml
@@ -80,7 +80,10 @@ jobs:
     strategy:
       matrix:
         pkg: ['Spine-Database-API', 'spine-engine', 'spine-items', 'Spine-Toolbox']
+        # TODO: can this be done w/o a matrix strategy?  That will be more atomic.
 
+    permissions:
+      id-token: write
     uses: ./.github/workflows/publish-wheel.yml
     with:
       pkg: ${{ matrix.pkg }}

--- a/.github/workflows/test-wheel.yml
+++ b/.github/workflows/test-wheel.yml
@@ -36,7 +36,7 @@ jobs:
       with:
         repository: 'spine-tools/${{ inputs.pkg }}'
         path: ${{ inputs.pkg }}
-        ref: ${{ inputs[inputs.pkg] != 'skip' && inputs[matrix.pkg] || 'master' }}
+        ref: ${{ inputs.ver }}
     - name: Set up Python ${{ inputs.python }}
       uses: actions/setup-python@v5
       with:
@@ -51,7 +51,7 @@ jobs:
       if: runner.os == 'Windows'
       run: |
         python -m pip install --upgrade pip
-        Get-ChildItem ./dist/*.whl -Recurse | ForEach-Object {python -m pip install $_}
+        python -m pip install $(Get-ChildItem ./dist/*/*.whl).FullName
         python -m pip install pytest
     - name: Install additional packages for Linux
       if: runner.os == 'Linux'

--- a/.github/workflows/test-wheel.yml
+++ b/.github/workflows/test-wheel.yml
@@ -1,0 +1,81 @@
+name: Reusable workflow to publish Spine package wheels
+
+on:
+  workflow_call:
+    inputs:
+      pkg:
+        description: Package name
+        type: string
+        required: true
+      ver:
+        description: Release tag
+        type: string
+        required: true
+      os:
+        description: Operating System/Platform
+        type: string
+        required: true
+      python:
+        description: Python version
+        type: string
+        required: true
+
+jobs:
+  test-whl:
+    if: inputs.ver != 'skip'
+    runs-on: ${{ inputs.os }}
+    steps:
+    - name: Make dist directory
+      run: mkdir -p dist
+    - name: Download all wheels
+      uses: actions/download-artifact@v4
+      with:
+        path: dist
+    - name: Checkout ${{ inputs.pkg }}
+      uses: actions/checkout@v4
+      with:
+        repository: 'spine-tools/${{ inputs.pkg }}'
+        path: ${{ inputs.pkg }}
+        ref: ${{ inputs[inputs.pkg] != 'skip' && inputs[matrix.pkg] || 'master' }}
+    - name: Set up Python ${{ inputs.python }}
+      uses: actions/setup-python@v5
+      with:
+        python-version: ${{ inputs.python }}
+    - name: Install pytest and built wheels on *NIX
+      if: runner.os != 'Windows'
+      run: |
+        python -m pip install --upgrade pip
+        python -m pip install dist/*/*.whl
+        python -m pip install pytest
+    - name: Install pytest and built wheels on Windows
+      if: runner.os == 'Windows'
+      run: |
+        python -m pip install --upgrade pip
+        Get-ChildItem ./dist/*.whl -Recurse | ForEach-Object {python -m pip install $_}
+        python -m pip install pytest
+    - name: Install additional packages for Linux
+      if: runner.os == 'Linux'
+      run: |
+        sudo apt-get update -y
+        sudo apt-get install -y libegl1
+    - name: Remove source from checkouts for *NIX
+      if: runner.os != 'Windows'
+      run: |
+        rm -rf Spine-Toolbox/spinetoolbox* spine-items/spine_items \
+          spine-engine/spine_engine Spine-Database-API/spinedb_api
+    - name: Remove source from checkouts for Windows
+      if: runner.os == 'Windows'
+      run: |
+        Remove-Item Spine-Toolbox\spinetoolbox* -Recurse -Force -ErrorAction Ignore
+        Remove-Item spine-items\spine_items -Recurse -Force -ErrorAction Ignore
+        Remove-Item spine-engine\spine_engine -Recurse -Force -ErrorAction Ignore
+        Remove-Item Spine-Database-API\spinedb_api -Recurse -Force -ErrorAction Ignore
+    - name: Test wheels
+      env:
+        QT_QPA_PLATFORM: offscreen
+      run: |
+        python -m unittest discover -s ${{ inputs.pkg }} --verbose
+    - name: Execution tests
+      if: inputs.pkg == 'Spine-Toolbox'
+      run: |
+        python -m unittest discover -s ${{ inputs.pkg }} --pattern execution_test.py --verbose

--- a/.github/workflows/unittests.yml
+++ b/.github/workflows/unittests.yml
@@ -24,9 +24,9 @@ jobs:
 
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           allow-prereleases: true
           python-version: ${{ matrix.python-version }}
@@ -49,7 +49,7 @@ jobs:
 
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Ruff with Python target version ${{ matrix.pyver }}
         uses: chartboost/ruff-action@v1
         with:
@@ -78,9 +78,9 @@ jobs:
       - name: Disable autocrlf so that we can test preserve LE on Windows
         if: matrix.os == 'windows-latest'
         run: git config --global core.autocrlf ${{ matrix.autocrlf }}
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           allow-prereleases: true
           python-version: ${{ matrix.python-version }}
@@ -104,9 +104,9 @@ jobs:
     runs-on: ubuntu-latest
     continue-on-error: true
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           allow-prereleases: true
           python-version: ${{ matrix.python-version }}

--- a/docs/design.md
+++ b/docs/design.md
@@ -70,3 +70,34 @@ are the following (latest existing tag is **0.3.1**):
 Preference:
 - `release-branch-semver`: forward-looking (current choice)
 - `post-release`: clear and concise
+
+# Release workflow
+
+```mermaid
+---
+title: Build
+---
+flowchart TD
+    subgraph projects
+      direction TB
+      A1(["project 1"]) -.- A2(["project 2 (skip)"]) -.- An(["project n"])
+    end
+    projects --> B{version == 'skip'? }
+    B -- yes --> C(download latest <br/> wheel from PyPI)
+    B -- no --> D(build wheel <br/> from source)
+    C --> E([Upload wheels <br/> as artifact])
+    D --> E
+```
+
+```mermaid
+---
+title: Test
+---
+flowchart TD
+    P([project]) --> F{version == 'skip'?}
+    F -- yes --> Z([stop])
+    F -- no --> G[Download all wheel <br/> artifacts and install]
+    G --> tests[[Test for supported <br/> Python versions]]
+    tests -- all pass --> H(["Publish to PyPI <br/> (separate workflow)"])
+    tests -- any fail -->I([Nothing published])
+```


### PR DESCRIPTION
## Summary
- Update actions to latest versions
- Add flowchart documentation about workflow structure 
- Factor out testing to a reusable workflow.  Remove "if skip" checks in between steps, making the logic linear and easier to follow
  - Fix a bug in the windows installation step, earlier it was installing one wheel at a time.  This could inadvertently pull in already published version of dependent (spine) packages.  Installing with a single `pip install *.whl` means spine dependencies are satisfied locally, no risk of pulling in unknown versions from PyPI.
- Factor out build & download to composite local actions, similar to above, this makes the "if skip" condition simpler (in this case reduced to a single `if skip: download else: build`)

Testing of the action in the toy repo can be found [here](https://github.com/suvayu/scm/actions/runs/10746253414).

Unfortunately I had to delete the new tags from the example repos (`scm*`) otherwise it interferes with the unit tests here.  I need to come up with a better way to setup the unit tests :thinking:.

Deleted tags on `scm*`:
- `scm`: 0.7.3, 0.7.4
- `scm-dep`: 0.2.4
- `scm-base`: 0.3.3

## Related

Supersedes #23
