### PR TITLE
Drop Python 3.8 from publishing test matrix

### DIFF
--- a/.github/workflows/test-n-publish.yml
+++ b/.github/workflows/test-n-publish.yml
@@ -64,7 +64,7 @@ jobs:
       matrix:
         pkg: ['Spine-Database-API', 'spine-engine', 'spine-items', 'Spine-Toolbox']
         os: [ubuntu-latest, windows-latest]
-        python: ["3.8", "3.9", "3.10", "3.11", "3.12"]
+        python: ["3.9", "3.10", "3.11", "3.12"]
       fail-fast: false
 
     uses: ./.github/workflows/test-wheel.yml


### PR DESCRIPTION
Toolbox does not support 3.8 anymore.