### PR TITLE
Temporarily disable attestations when publishing

### DIFF
--- a/.github/workflows/publish-wheel.yml
+++ b/.github/workflows/publish-wheel.yml
@@ -32,3 +32,5 @@ jobs:
         packages-dir: dist/${{ inputs.pkg }}
         # skip-existing: true
         # verify-metadata: false
+        # Temporary workaround for https://github.com/pypa/gh-action-pypi-publish/issues/283
+        attestations: false


### PR DESCRIPTION
Workaround for
https://github.com/pypa/gh-action-pypi-publish/issues/283

According to the discussion in the link above, we may need to consider not using a reusable workflow for publishing.