### PR TITLE
Add Python 3.14 to publication process

### DIFF
--- a/.github/workflows/test-n-publish.yml
+++ b/.github/workflows/test-n-publish.yml
@@ -25,7 +25,7 @@ jobs:
     strategy:
       matrix:
         pkg: ['Spine-Database-API', 'spine-engine', 'spine-items', 'Spine-Toolbox']
-        python: ["3.12"]
+        python: ["3.14"]
 
     runs-on: ubuntu-latest
     steps:
@@ -64,7 +64,7 @@ jobs:
       matrix:
         pkg: ['Spine-Database-API', 'spine-engine', 'spine-items', 'Spine-Toolbox']
         os: [ubuntu-latest, windows-latest]
-        python: ["3.10", "3.11", "3.12", "3.13"]
+        python: ["3.10", "3.11", "3.12", "3.13", "3.14"]
       fail-fast: false
 
     uses: ./.github/workflows/test-wheel.yml

--- a/.github/workflows/test-wheel.yml
+++ b/.github/workflows/test-wheel.yml
@@ -47,16 +47,12 @@ jobs:
         python -m pip install --upgrade pip
         python -m pip install dist/*/*.whl
         python -m pip install pytest
-        python -m pip install PySide6!=6.10.1
-        # temporarily exclude pyside version causing a crash
     - name: Install pytest and built wheels on Windows
       if: runner.os == 'Windows'
       run: |
         python -m pip install --upgrade pip
         python -m pip install $(Get-ChildItem ./dist/*/*.whl).FullName
         python -m pip install pytest
-        python -m pip install PySide6!=6.10.1
-        # temporarily exclude pyside version causing a crash
     - name: Install additional packages for Linux
       if: runner.os == 'Linux'
       run: |


### PR DESCRIPTION
Toolbox now supports Python 3.14, so why not use it here?